### PR TITLE
[DPB] Fix typo for Ethernet0 2x200G[100G,40G] breakout mode

### DIFF
--- a/device/barefoot/x86_64-accton_as9516_32d-r0/platform.json
+++ b/device/barefoot/x86_64-accton_as9516_32d-r0/platform.json
@@ -286,7 +286,7 @@
             "lanes": "0,1,2,3,4,5,6,7",
             "breakout_modes": {
                 "1x400G[200G]": ["Ethernet0"],
-                "2x200G[100G,40G]": ["Ethernet0, Ethernet4"],
+                "2x200G[100G,40G]": ["Ethernet0", "Ethernet4"],
                 "4x100G[50G]": ["Ethernet0", "Ethernet2", "Ethernet4", "Ethernet6"],
                 "8x50G[25G,10G]": ["Ethernet0", "Ethernet1", "Ethernet2", "Ethernet3", "Ethernet4", "Ethernet5", "Ethernet6", "Ethernet7"],
                 "1x200G[100G,40G](4)+4x50G[25G,10G](4)": ["Ethernet0", "Ethernet4", "Ethernet5", "Ethernet6", "Ethernet7"],


### PR DESCRIPTION
Signed-off-by: Mykola Gerasymenko <mykolax.gerasymenko@intel.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Dynamic port breakout fails for Ethernet0 with breakout mode 2x200G[100G,40G].

#### How I did it
Fixed double quotes typo for Ethernet0 breakout mode 2x200G[100G,40G]. 

#### How to verify it
Run the command config interface breakout <interface> <breakout_mode>

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

